### PR TITLE
add cpp C extern for inclusion from cpp projects

### DIFF
--- a/fseq.h
+++ b/fseq.h
@@ -8,6 +8,10 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Boolean type.
 typedef char FSeqBool;
 #define FSEQ_TRUE 1
@@ -122,5 +126,9 @@ struct FSeqDirEntry* fseqDirList(
 
 // Delete a directory list.
 void fseqDirListDel(struct FSeqDirEntry*);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif // FSEQ_H


### PR DESCRIPTION
this avoids the need to wrap an inclusion of fseq.h with extern "C". The reason to avoid that scenario is that fseq.h itself includes other headers; so it's possibly a bit fraught to wrap things in the c std library with extern "C". It's probably fine,,,,, but it's way safer to have the extern in the fseq.h file itself. 